### PR TITLE
Add python-dotenv to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ pycparser==2.22
 Pygments==2.18.0
 pyOpenSSL==24.1.0
 python-dateutil==2.9.0.post0
+python-dotenv==1.0.1
 pytz==2024.1
 pywin32==306
 pyzmq==26.0.3


### PR DESCRIPTION
Included python-dotenv==1.0.1 to manage environment variables in the application. This change helps streamline configuration handling and avoids hardcoding sensitive data. Ensures smoother deployment and better security practices.